### PR TITLE
[#17] Add GCS Bucket for Container Registry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@
   hooks:
     - id: terraform_fmt
     - id: terraform_validate_no_variables
+#    - id: terraform_docs

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -70,6 +70,7 @@ provider google-beta {
 |------|-------------|
 | bastion\_ip | Bastion IP Address |
 | bastion\_subnetwork\_selflink | Selflink for the Bastion SubNetwork |
+| container\_registry\_bucket\_name | Cloud Storage Bucket Name to be used for Container Registry |
 | gke\_cluster\_master\_cidr | CIDR Range for Cluster Master |
 | gke\_cluster\_pods\_cidr | CIDR Range for Cluster Pods |
 | gke\_cluster\_services\_cidr | CIDR Range for Cluster Services |

--- a/gcp/buckets.tf
+++ b/gcp/buckets.tf
@@ -1,0 +1,12 @@
+data "google_client_config" "current" {}
+
+resource "google_storage_bucket" "container_registry" {
+  name          = "${data.google_client_config.current.project}-registry"
+  location      = "${var.region}"
+  storage_class = "MULTI_REGIONAL"
+  force_destroy = "true"
+
+  labels = {
+    "managed-by" = "terraform"
+  }
+}

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -44,5 +44,6 @@ output "gke_cluster_master_cidr" {
 }
 
 output "container_registry_bucket_name" {
-  value = "${google_storage_bucket.container_registry.name}"
+  value       = "${google_storage_bucket.container_registry.name}"
+  description = "Cloud Storage Bucket Name to be used for Container Registry"
 }

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -42,3 +42,7 @@ output "gke_cluster_master_cidr" {
   value       = "${google_container_cluster.primary.private_cluster_config.0.master_ipv4_cidr_block}"
   description = "CIDR Range for Cluster Master"
 }
+
+output "container_registry_bucket_name" {
+  value = "${google_storage_bucket.container_registry.name}"
+}


### PR DESCRIPTION
Github Issue: https://github.com/astronomer/terraform/issues/17

The bucket is created for all environments. This can optionally be to back container registry.