### PR TITLE
Add optional Istio integration for GKE cluster

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -83,4 +83,8 @@ resource "google_container_cluster" "primary" {
   network_policy = {
     enabled = true
   }
+
+  istio_config {
+    disabled = false
+  }    
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -86,7 +86,9 @@ resource "google_container_cluster" "primary" {
     enabled = true
   }
 
-  istio_config {
-    disabled = false
-  }    
+  addons_config {
+    istio_config {
+      disabled = false
+    }
+  }  
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -90,5 +90,5 @@ resource "google_container_cluster" "primary" {
     istio_config {
       disabled = false
     }
-  }  
+  }
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -37,6 +37,8 @@ resource "google_container_node_pool" "np" {
 
 # GKE cluster
 resource "google_container_cluster" "primary" {
+  provider = "google-beta"
+
   name               = "${var.cluster_name}"
   location           = "${var.region}"
   min_master_version = "${var.min_master_version}"

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -88,7 +88,8 @@ resource "google_container_cluster" "primary" {
 
   addons_config {
     istio_config {
-      disabled = false
+      disabled = "${var.istio_disabled}"
+      auth     = "${var.istio_auth}"
     }
   }
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -88,3 +88,11 @@ variable "bastion_image_family" {
     project = "ubuntu-os-cloud"
   }
 }
+
+variable "istio_disabled" {
+  default = true
+}
+
+variable "istio_auth" {
+  default = "AUTH_MUTUAL_TLS"
+}


### PR DESCRIPTION
* Adds the option to enable Istio integration for GKE cluster resource
* Disabled by default, can be overridden with variable `istio_disabled = false`

Related to #2 